### PR TITLE
Changes done to make ChaosMonkey extensible for in-house deployments such as IIS servers.

### DIFF
--- a/ChaosMonkey.Tests/App.config
+++ b/ChaosMonkey.Tests/App.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="AWSAccessKey" value="joy"/>
+    <add key="AWSSecretKey"
+         value="joy's key"/>
+  </appSettings>
+</configuration>

--- a/ChaosMonkey.Tests/ChaosMonkey.Tests.csproj
+++ b/ChaosMonkey.Tests/ChaosMonkey.Tests.csproj
@@ -38,6 +38,9 @@
       <HintPath>..\Referenced Assemblies\AWSSDK.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core">
@@ -52,6 +55,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BasicTests.cs" />
+    <Compile Include="MonkeyKeeper_UnleashRandomMonkey.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ChaosMonkey\ChaosMonkey.csproj">
@@ -60,14 +64,13 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Settings.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ChaosMonkey.Tests/packages.config
+++ b/ChaosMonkey.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net40" />
+</packages>

--- a/ChaosMonkey/ChaosMonkey.csproj
+++ b/ChaosMonkey/ChaosMonkey.csproj
@@ -51,12 +51,22 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommandLineParser.cs" />
+    <Compile Include="CommandLineSettings.cs" />
+    <Compile Include="CommandLineValidator.cs" />
     <Compile Include="Domain\Ec2Endpoint.cs" />
     <Compile Include="Domain\Settings.cs" />
+    <Compile Include="HardCodedMonkeyListBuilder.cs" />
     <Compile Include="Infrastructure\ChaosLogger.cs" />
+    <Compile Include="Infrastructure\CommandExecuter.cs" />
     <Compile Include="Infrastructure\Ec2Factory.cs" />
-    <Compile Include="Tasks.cs" />
+    <Compile Include="MonkeyKeeper.cs" />
+    <Compile Include="MonkeyListBuilder.cs" />
+    <Compile Include="Monkeys\EC2Monkey.cs" />
+    <Compile Include="Monkeys\IISServerMonkey.cs" />
+    <Compile Include="Monkeys\ParentMonkey.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="Tasks.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ChaosMonkey/CommandLineParser.cs
+++ b/ChaosMonkey/CommandLineParser.cs
@@ -1,0 +1,96 @@
+using ChaosMonkey.Domain;
+using NDesk.Options;
+using System;
+using System.IO;
+
+namespace ChaosMonkey
+{
+    internal class CommandLineParser
+    {
+        OptionSet _options;
+        string[] _args;
+        internal CommandLineParser(string [] args)
+        {
+            _args = args;
+        }
+        internal CommandLineSettings GetCommandLineSettings()
+        {
+            var commandLineSettings = new CommandLineSettings() { Settings = new Settings() };
+
+            _options = new OptionSet()
+                                    {
+                                        {
+                                            "a=|awsaccesskey=",
+                                            "Access key of AWS IAM user that can list and terminate instances",
+                                            x =>commandLineSettings.Settings.AwsAccessKey = x
+                                            },
+                                        {
+                                            "d=|delay=",
+                                            "Delay (milliseconds) before chaos is unleashed again (if repeat option set)",
+                                            (int x) => commandLineSettings.Settings.Delay = x
+                                            },
+                                        {
+                                            "D|acceptdisclaimer",
+                                            "Chaos Monkey is designed to break stuff, setting this option means that you acknowledge this",
+                                            x => commandLineSettings.AcceptDisclaimer = x != null
+                                            },
+                                        {
+                                            "e=|endpoint=",
+                                            "AWS endpoint name (US-East, US-West, EU, Asia-Pacific-Singapore, Asia-Pacific-Japan)",
+                                            x => commandLineSettings.Settings.Ec2Endpoint = x
+                                            },
+                                        {
+                                            "h|?|help",
+                                            "Show help (this screen)",
+                                            x =>commandLineSettings.ShowHelp = x != null
+                                            },
+                                        {
+                                            "i=|loadsettings=", "Load settings xml file", x => commandLineSettings.LoadSettingsFile = x
+                                            },
+                                        {
+                                            "l=|log=", "Save log to file", x => commandLineSettings.Settings.LogFileName = x
+                                            },
+                                        {
+                                            "o=|savesettings=", "Save settings to xml file",
+                                            x => commandLineSettings.SaveSettingsFile = x
+                                            },
+                                        {
+                                            "r=|repeat=",
+                                            "Number of times chaos is unleashed (default 1)",
+                                            (int x) => commandLineSettings.Settings.Repeat = x
+                                            },
+                                        {
+                                            "s=|awssecretkey=",
+                                            "Access key of AWS IAM user that can list and terminate instances",
+                                            x => commandLineSettings.Settings.AwsSecretKey = x
+                                            },
+                                        {
+                                            "S=|serviceurl=",
+                                            "URL of EC2 service endpoint (use e|endpoint to use defaults)",
+                                            x => commandLineSettings.Settings.ServiceUrl = x
+                                            },
+                                        {
+                                            "t=|tagkey=", "Key of Tag that will be search for in instances e.g. if EC2 tag is chaos=1, ChaosMonkey TagKey=chaos",
+                                            x => commandLineSettings.Settings.Tagkey = x
+                                            },
+                                        {
+                                            "v=|tagvalue=", "Value of Tag that will be search for in instances e.g. if EC2 tag is chaos=1, ChaosMonkey TagValue=1",
+                                            x => commandLineSettings.Settings.TagValue = x
+                                            },
+                                        {
+                                            "m=|mode=",
+                                            "Application mode which decides whether to run in AWS only mode or load plugins.eg. m=Pluggable for loading other plugins",
+                                            (ApplicationMode x)=>commandLineSettings.ApplicationMode=x
+                                        }
+                                    };
+
+            _options.Parse(_args);
+            return commandLineSettings;
+        }
+
+        internal void WriteOptionDescriptions(TextWriter writer)
+        {
+            _options.WriteOptionDescriptions(writer);
+        }
+    }
+}

--- a/ChaosMonkey/CommandLineSettings.cs
+++ b/ChaosMonkey/CommandLineSettings.cs
@@ -1,0 +1,18 @@
+﻿using ChaosMonkey.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ChaosMonkey
+{
+    class CommandLineSettings
+    {
+        public Settings Settings { get; set; }
+        public bool ShowHelp { get; set; } = false;
+        public string SaveSettingsFile { get; set; } = string.Empty;
+        public bool AcceptDisclaimer { get; set; } = false;
+        public string LoadSettingsFile { get; set; } = string.Empty;
+        public ApplicationMode ApplicationMode { get; set; } = ApplicationMode.Default;
+    }
+}

--- a/ChaosMonkey/CommandLineValidator.cs
+++ b/ChaosMonkey/CommandLineValidator.cs
@@ -1,0 +1,54 @@
+﻿using ChaosMonkey.Domain;
+using ChaosMonkey.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ChaosMonkey
+{
+    class CommandLineValidator
+    {
+        private static string ServiceUrlFromEndPointName(string endPointName)
+        {
+            var ec2Endpoints = new Ec2Endpoints();
+            var serviceUrl = string.Empty;
+            ec2Endpoints.Endpoints.TryGetValue(endPointName, out serviceUrl);
+            return serviceUrl;
+        }
+
+        public static bool ValidateSettings(Settings settings, ChaosLogger logger)
+        {
+            var settingsValid = true;
+            if (string.IsNullOrEmpty(settings.ServiceUrl) && !string.IsNullOrEmpty(settings.Ec2Endpoint))
+            {
+                settings.ServiceUrl = ServiceUrlFromEndPointName(settings.Ec2Endpoint);
+                if (string.IsNullOrEmpty(settings.ServiceUrl))
+                {
+                    logger.Log("ERROR: Cannot find service url for endpoint '" + settings.Ec2Endpoint + "'");
+                    settingsValid = false;
+                }
+            }
+
+            if (string.IsNullOrEmpty(settings.ServiceUrl))
+            {
+                logger.Log("ERROR: No service URL found");
+                settingsValid = false;
+            }
+
+            if (string.IsNullOrEmpty(settings.Tagkey))
+            {
+                logger.Log("ERROR: Tag key needed");
+                settingsValid = false;
+            }
+
+            if (string.IsNullOrEmpty(settings.TagValue))
+            {
+                logger.Log("ERROR: Tag value needed");
+                settingsValid = false;
+            }
+
+            return settingsValid;
+        }
+    }
+}

--- a/ChaosMonkey/Domain/Settings.cs
+++ b/ChaosMonkey/Domain/Settings.cs
@@ -1,6 +1,13 @@
 ﻿namespace ChaosMonkey.Domain
 {
-    public class Settings
+    public class SettingsBase
+    {
+        public int Repeat { get; set; }
+        public int Delay { get; set; }
+        public bool AcceptedDisclaimer { get; set; }
+        public string LogFileName { get; set; }
+    }
+    public class Settings : SettingsBase
     {
         public string AwsAccessKey { get; set; }
         public string AwsSecretKey { get; set; }
@@ -8,9 +15,5 @@
         public string Tagkey { get; set; }
         public string TagValue { get; set; }
         public string ServiceUrl { get; set; }
-        public int Repeat { get; set; }
-        public int Delay { get; set; }
-        public bool AcceptedDisclaimer { get; set; }
-        public string LogFileName { get; set; }
     }
 }

--- a/ChaosMonkey/HardCodedMonkeyListBuilder.cs
+++ b/ChaosMonkey/HardCodedMonkeyListBuilder.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ChaosMonkey.Domain;
+using ChaosMonkey.Infrastructure;
+using ChaosMonkey.Monkeys;
+
+namespace ChaosMonkey
+{
+    internal class HardCodedMonkeyListBuilder :MonkeyListBuilder
+    {
+        public override IList<ParentMonkey> GetMonkeys(Settings settings, ChaosLogger logger)
+        {
+            logger.Log("Hard coded MonkyeListProvider returning EC2Monkey");
+                return new List<ParentMonkey>() { new EC2Monkey(settings, logger) };
+        }
+    }
+}

--- a/ChaosMonkey/Infrastructure/ChaosLogger.cs
+++ b/ChaosMonkey/Infrastructure/ChaosLogger.cs
@@ -13,6 +13,10 @@
             {
                 logStream = File.AppendText(fileName);
             }
+            else
+            {
+                logStream =new StreamWriter( Console.OpenStandardOutput());
+            }
         }
 
         public void Log(string message)

--- a/ChaosMonkey/Infrastructure/CommandExecuter.cs
+++ b/ChaosMonkey/Infrastructure/CommandExecuter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ChaosMonkey.Infrastructure
+{
+    class CommandExecuter
+    {
+        public void ExecuteCommandSync(string command)
+        {
+            try
+            {
+                System.Diagnostics.ProcessStartInfo procStartInfo =
+                    new System.Diagnostics.ProcessStartInfo("cmd", "/c " + command);
+
+                procStartInfo.RedirectStandardOutput = true;
+                procStartInfo.UseShellExecute = false;
+
+                procStartInfo.CreateNoWindow = true;
+
+                System.Diagnostics.Process proc = new System.Diagnostics.Process();
+                proc.StartInfo = procStartInfo;
+                proc.Start();
+
+                string result = proc.StandardOutput.ReadToEnd();
+
+                Console.WriteLine(result);
+            }
+            catch (Exception ex)
+            {
+
+            }
+        }
+    }
+}

--- a/ChaosMonkey/MonkeyKeeper.cs
+++ b/ChaosMonkey/MonkeyKeeper.cs
@@ -1,0 +1,43 @@
+﻿using ChaosMonkey.Domain;
+using ChaosMonkey.Infrastructure;
+using ChaosMonkey.Monkeys;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ChaosMonkey
+{
+    public class MonkeyKeeper
+    {
+        IList<ParentMonkey> _monkeys;
+        Settings _settings;
+        ChaosLogger _logger;
+        MonkeyListBuilder _builder;
+        Random random;
+        public MonkeyKeeper(Settings setting,ChaosLogger logger, MonkeyListBuilder listBuilder) {
+            _settings = setting;
+            _logger = logger;
+            _builder = listBuilder;
+        }
+        public void UnleashRandomMonkey()
+        {
+            BuildMonkeysListAndInitializeRandomSeedIfNotDoneAlready();
+            int nextRandomNumber = random.Next(_monkeys.Count);
+            ParentMonkey monkey = _monkeys[nextRandomNumber];
+            _logger.Log(string.Format("Unleashing random Monkey named {0}",monkey));
+            monkey.Unleash();
+        }
+
+        private void BuildMonkeysListAndInitializeRandomSeedIfNotDoneAlready()
+        {
+            if (_monkeys == null)
+            {
+                _logger.Log("Building Monkey's List");
+                _monkeys = _builder.GetMonkeys(_settings, _logger);
+                _logger.Log("Initializing Random as the Monkey's count changes");
+                random = new Random(_monkeys.Count);
+            }
+        }
+    }
+}

--- a/ChaosMonkey/MonkeyListBuilder.cs
+++ b/ChaosMonkey/MonkeyListBuilder.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using ChaosMonkey.Monkeys;
+using ChaosMonkey.Infrastructure;
+using ChaosMonkey.Domain;
+
+namespace ChaosMonkey
+{
+    abstract public class MonkeyListBuilder
+    {
+        public MonkeyListBuilder()
+        {
+        }
+        /// <summary>
+        /// Gives the list of Monkeys
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <param name="logger"></param>
+        /// <returns></returns>
+        public abstract IList<ParentMonkey> GetMonkeys(Settings settings,ChaosLogger logger);
+    }
+}

--- a/ChaosMonkey/Monkeys/EC2Monkey.cs
+++ b/ChaosMonkey/Monkeys/EC2Monkey.cs
@@ -1,0 +1,51 @@
+﻿using Amazon.EC2.Model;
+using ChaosMonkey.Domain;
+using ChaosMonkey.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ChaosMonkey.Monkeys
+{
+    /// <summary>
+    /// Randomly terminate AWS instance.
+    /// </summary>
+    class EC2Monkey :ParentMonkey
+    {
+        public EC2Monkey(Settings settings, ChaosLogger logger) : base(settings, logger) { }
+        public override void Unleash()
+        {
+            var random = new Random();
+            var ec2Factory = new Ec2Factory(_settings.AwsAccessKey, _settings.AwsSecretKey, _settings.ServiceUrl, _logger);
+            _logger.Log(string.Format("Looking for instances in {0} with tag {1}={2}", _settings.ServiceUrl, _settings.Tagkey, _settings.TagValue));
+
+            List<Reservation> instances;
+            try
+            {
+                instances = ec2Factory.ListInstancesByTag(_settings.Tagkey, _settings.TagValue);
+            }
+            catch (Exception ex)
+            {
+                _logger.Log("ERROR: " + ex.Message);
+                return;
+            }
+
+            if (instances.Count == 0)
+            {
+                _logger.Log("No instances found");
+            }
+            else
+            {
+                _logger.Log(string.Format("Found {0} candidate instance(s) for chaos!", instances.Count));
+                var victimIndex = random.Next(0, instances.Count);
+                var instanceId = instances[victimIndex].RunningInstance[0].InstanceId;
+                _logger.Log(string.Format("Randomly chosen instance {0} ({1}) as the chaos victim.", instanceId, instances[victimIndex].RunningInstance[0].PublicDnsName));
+                _logger.Log(string.Format("Terminating {0}...", instanceId));
+
+                ec2Factory.TerminateInstance(instanceId);
+                _logger.Log(string.Format("{0} terminated", instanceId));
+            }
+        }
+    }
+}

--- a/ChaosMonkey/Monkeys/IISServerMonkey.cs
+++ b/ChaosMonkey/Monkeys/IISServerMonkey.cs
@@ -1,0 +1,30 @@
+﻿using ChaosMonkey.Domain;
+using ChaosMonkey.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ChaosMonkey.Monkeys
+{
+    /// <summary>
+    /// IIS Monkey who randomly restart IIS servers / IIS AppPools in a deployment.
+    /// </summary>
+    /// <remarks>Move this class to different assembly if it needs extra dll references</remarks>
+    public class IISServerMonkey :ParentMonkey
+    {
+        public IISServerMonkey(Settings settings,ChaosLogger logger) :base(settings,logger)
+        {
+
+        }
+        public override void Unleash()
+        {
+            _logger.Log("Restarting local IIS");
+            RestartLocalIIS("localhost");
+        }
+        private void RestartLocalIIS(string serverName)
+        {
+            new CommandExecuter().ExecuteCommandSync("iisreset");
+        }
+    }
+}

--- a/ChaosMonkey/Monkeys/ParentMonkey.cs
+++ b/ChaosMonkey/Monkeys/ParentMonkey.cs
@@ -1,0 +1,21 @@
+﻿using ChaosMonkey.Domain;
+using ChaosMonkey.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ChaosMonkey.Monkeys
+{
+    abstract public class ParentMonkey
+    {
+        protected ChaosLogger _logger;
+        protected Settings _settings;
+        public ParentMonkey(Settings settings, ChaosLogger logger)
+        {
+            _logger = logger;
+            _settings = settings;
+        }
+        public abstract void Unleash();
+    }
+}

--- a/ChaosMonkey/Program.cs
+++ b/ChaosMonkey/Program.cs
@@ -4,144 +4,122 @@
     using Domain;
     using Infrastructure;
     using NDesk.Options;
+    enum ApplicationMode
+    {
+        Default,
+        Pluggable
+    }
 
     class Program
     {
         static void Main(string[] args)
         {
-            var settings = new Settings();
-            var showHelp = false;
-            var saveSettingsFile = string.Empty;
-            var acceptDisclaimer = false;
-            var loadSettingsFile = string.Empty;
-
-            var options = new OptionSet()
-                                    {
-                                        {
-                                            "a=|awsaccesskey=",
-                                            "Access key of AWS IAM user that can list and terminate instances",
-                                            x => settings.AwsAccessKey = x
-                                            },
-                                        {
-                                            "d=|delay=",
-                                            "Delay (milliseconds) before chaos is unleashed again (if repeat option set)",
-                                            (int x) => settings.Delay = x
-                                            },
-                                        {
-                                            "D|acceptdisclaimer",
-                                            "Chaos Monkey is designed to break stuff, setting this option means that you acknowledge this",
-                                            x => acceptDisclaimer = x != null
-                                            },
-                                        {
-                                            "e=|endpoint=",
-                                            "AWS endpoint name (US-East, US-West, EU, Asia-Pacific-Singapore, Asia-Pacific-Japan)",
-                                            x => settings.Ec2Endpoint = x
-                                            },
-                                        {
-                                            "h|?|help",
-                                            "Show help (this screen)",
-                                            x => showHelp = x != null
-                                            },
-                                        {
-                                            "i=|loadsettings=", "Load settings xml file", x => loadSettingsFile = x
-                                            },
-                                        {
-                                            "l=|log=", "Save log to file", x => settings.LogFileName = x
-                                            },
-                                        {
-                                            "o=|savesettings=", "Save settings to xml file", x => saveSettingsFile = x
-                                            },
-                                        {
-                                            "r=|repeat=",
-                                            "Number of times chaos is unleashed (default 1)",
-                                            (int x) => settings.Repeat = x
-                                            },
-                                        {
-                                            "s=|awssecretkey=",
-                                            "Access key of AWS IAM user that can list and terminate instances",
-                                            x => settings.AwsSecretKey = x
-                                            },
-                                        {
-                                            "S=|serviceurl=",
-                                            "URL of EC2 service endpoint (use e|endpoint to use defaults)",
-                                            x => settings.ServiceUrl = x
-                                            },
-                                        {
-                                            "t=|tagkey=", "Key of Tag that will be search for in instances e.g. if EC2 tag is chaos=1, ChaosMonkey TagKey=chaos",
-                                            x => settings.Tagkey = x
-                                            },
-                                        {
-                                            "v=|tagvalue=", "Value of Tag that will be search for in instances e.g. if EC2 tag is chaos=1, ChaosMonkey TagValue=1",
-                                            x => settings.TagValue = x
-                                            }
-                                    };
-
-            options.Parse(args);
-
-            var logger = new ChaosLogger(settings.LogFileName);
+            CommandLineParser parser = new CommandLineParser(args);
+            CommandLineSettings commandLineSettings= parser.GetCommandLineSettings();
+            var logger = new ChaosLogger(commandLineSettings.Settings.LogFileName);
             try
             {
-                if (!string.IsNullOrEmpty(loadSettingsFile))
-                {
-                    try
-                    {
-                        Tasks.LoadSettings(loadSettingsFile, logger);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.Log("ERROR: " + ex.Message);
-                        return;
-                    }
-                }
+                LoadSettings(commandLineSettings.LoadSettingsFile, logger);
 
-                if (!acceptDisclaimer)
+                if (IsDisclaimerAccepted(commandLineSettings.AcceptDisclaimer, logger))
                 {
-                    Console.WriteLine("WARNING!!! ChaosMonkey is going to break stuff. Press 'D' to indemnify the ChaosMonkey or its authors/contributors to your actions");
-                    var key = Console.ReadKey();
-                    Console.WriteLine();
-                    if (key.KeyChar != 'D')
-                    {
-                        logger.Log("Disclaimer not accepted, exiting");
-                        return;
-                    }
 
-                    logger.Log("Disclaimer accepted.");
                 }
                 else
                 {
-                    logger.Log("Disclaimer accepted via startup parameters.");
-                }
-
-                if (!Tasks.ValidateSettings(settings, logger))
-                {
-                    logger.Log("Invalid settings. use '-?' for help on parameters. Exiting.");
+                    logger.Log("Disclaimer not accepted, exiting");
                     return;
                 }
-
-                Tasks.UnleashChaos(settings, logger);
-
-                if (!string.IsNullOrEmpty(saveSettingsFile))
+                if (commandLineSettings.ApplicationMode.Equals("Pluggable"))
                 {
-                    logger.Log(string.Format("Saving settings to {0}", saveSettingsFile));
-                    try
+                }
+                else
+                {
+                    if (!CommandLineValidator.ValidateSettings(commandLineSettings.Settings, logger))
                     {
-                        Tasks.SaveSettings(saveSettingsFile, settings, logger);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.Log("ERROR: " + ex.Message);
+                        logger.Log("Invalid settings. use '-?' for help on parameters. Exiting.");
+                        return;
                     }
                 }
+                
+
+                Tasks.UnleashChaos(commandLineSettings.Settings, logger);
+                SaveSettingsFile(commandLineSettings.SaveSettingsFile, commandLineSettings.Settings, logger);
             }
             finally
             {
                 logger.Close();
-                if (showHelp)
+                if (commandLineSettings.ShowHelp)
                 {
-                    options.WriteOptionDescriptions(Console.Out);
+                 parser.WriteOptionDescriptions(Console.Out);
                 }
             }
-            
+
+        }
+
+        private static bool IsDisclaimerAccepted(bool acceptDisclaimer, ChaosLogger logger)
+        {
+            if (!acceptDisclaimer)
+            {
+                if (IsDisclaimerAcceptedViaDialog(logger))
+                {
+                    logger.Log("Disclaimer accepted.");
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                logger.Log("Disclaimer accepted via startup parameters.");
+                return true;
+            }
+        }
+
+        private static bool IsDisclaimerAcceptedViaDialog(ChaosLogger logger)
+        {
+            Console.WriteLine("WARNING!!! ChaosMonkey is going to break stuff. Press 'D' to indemnify the ChaosMonkey or its authors/contributors to your actions");
+            var key = Console.ReadKey();
+            Console.WriteLine();
+            if (key.KeyChar != 'D')
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private static void LoadSettings(string loadSettingsFile, ChaosLogger logger)
+        {
+            if (!string.IsNullOrEmpty(loadSettingsFile))
+            {
+                try
+                {
+                    Tasks.LoadSettings(loadSettingsFile, logger);
+                }
+                catch (Exception ex)
+                {
+                    logger.Log("ERROR: " + ex.Message);
+                    return;
+                }
+            }
+        }
+
+        private static void SaveSettingsFile(string saveSettingsFile, Settings settings, ChaosLogger logger)
+        {
+            if (!string.IsNullOrEmpty(saveSettingsFile))
+            {
+                logger.Log(string.Format("Saving settings to {0}", saveSettingsFile));
+                try
+                {
+                    Tasks.SaveSettings(saveSettingsFile, settings, logger);
+                }
+                catch (Exception ex)
+                {
+                    logger.Log("ERROR: " + ex.Message);
+                }
+            }
         }
     }
 }

--- a/ChaosMonkey/Tasks.cs
+++ b/ChaosMonkey/Tasks.cs
@@ -7,6 +7,7 @@
     using Amazon.EC2.Model;
     using Domain;
     using Infrastructure;
+    using ChaosMonkey.Monkeys;
 
     public class Tasks
     {
@@ -44,52 +45,11 @@
         }
 
 
-        private static string ServiceUrlFromEndPointName(string endPointName)
-        {
-            var ec2Endpoints = new Ec2Endpoints();
-            var serviceUrl = string.Empty;
-            ec2Endpoints.Endpoints.TryGetValue(endPointName, out serviceUrl);
-            return serviceUrl;
-        }
-
-        public static bool ValidateSettings(Settings settings, ChaosLogger logger)
-        {
-            var settingsValid = true;
-            if (string.IsNullOrEmpty(settings.ServiceUrl) && !string.IsNullOrEmpty(settings.Ec2Endpoint))
-            {
-                settings.ServiceUrl = ServiceUrlFromEndPointName(settings.Ec2Endpoint);
-                if (string.IsNullOrEmpty(settings.ServiceUrl))
-                {
-                    logger.Log("ERROR: Cannot find service url for endpoint '" + settings.Ec2Endpoint + "'");
-                    settingsValid = false;
-                }
-            }
-
-            if (string.IsNullOrEmpty(settings.ServiceUrl))
-            {
-                logger.Log("ERROR: No service URL found");
-                settingsValid = false;
-            }
-
-            if (string.IsNullOrEmpty(settings.Tagkey))
-            {
-                logger.Log("ERROR: Tag key needed");
-                settingsValid = false;
-            }
-
-            if (string.IsNullOrEmpty(settings.TagValue))
-            {
-                logger.Log("ERROR: Tag value needed");
-                settingsValid = false;
-            }
-
-            return settingsValid;
-        }
+        
+        
 
         public static void UnleashChaos(Settings settings, ChaosLogger logger)
         {
-            var ec2Factory = new Ec2Factory(settings.AwsAccessKey, settings.AwsSecretKey, settings.ServiceUrl, logger);
-            var random = new Random();
             if (settings.Repeat == 0)
             {
                 settings.Repeat = 1;
@@ -99,40 +59,11 @@
             {
                 logger.Log(string.Format("Repeating {0} times", settings.Repeat));
             }
-            
-            for (var t = 0; t < settings.Repeat; t++)
+            MonkeyKeeper keeper = new MonkeyKeeper(settings, logger, new HardCodedMonkeyListBuilder());
+            for (var times = 0; times < settings.Repeat; times++)
             {
-                logger.Log(string.Format("Looking for instances in {0} with tag {1}={2}", settings.ServiceUrl, settings.Tagkey, settings.TagValue));
-
-                List<Reservation> instances;
-                try
-                {
-                    instances = ec2Factory.ListInstancesByTag(settings.Tagkey, settings.TagValue);
-                }
-                catch (Exception ex)
-                {
-                    logger.Log("ERROR: " + ex.Message);
-                    return;
-                }
-
-                if (instances.Count == 0)
-                {
-                    logger.Log("No instances found");
-                }
-                else
-                {
-                    logger.Log(string.Format("Found {0} candidate instance(s) for chaos!", instances.Count));
-                    var victimIndex = random.Next(0, instances.Count);
-                    var instanceId = instances[victimIndex].RunningInstance[0].InstanceId;
-                    logger.Log(string.Format("Randomly chosen instance {0} ({1}) as the chaos victim.", instanceId, instances[victimIndex].RunningInstance[0].PublicDnsName));
-                    logger.Log(string.Format("Terminating {0}...", instanceId));
-
-                    ec2Factory.TerminateInstance(instanceId);
-                    logger.Log(string.Format("{0} terminated", instanceId));
-                }
-
-                if (settings.Delay <= 0) continue;
-
+                keeper.UnleashRandomMonkey();
+                if (settings.Delay <= 0) return;
                 logger.Log(string.Format("Waiting {0} ms", settings.Delay));
                 System.Threading.Thread.Sleep(settings.Delay);
             }


### PR DESCRIPTION
Hi Simon,
We have a distributed computing platform and we are facing issues which are occuring first in production. That happens when somebody randomly restart IIS, Application Pool or the memory pressure increases. We needed to bring that issues to development and QA servers so that we can fail fast and recover from it. Inspired from original ChaosMonkey, I started writing one from scratch but in between I could see your version. So decided to make it usable for our requirement. 

After doing the changes thinking to share with you so that same developers in need can reuse the same.

Time being the pull request contains changes which are needed to make it pluggable. I have added a IISServerMonkey class which can be plugged to test local IIS.
